### PR TITLE
chore(release): v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Added `globset` for glob pattern matching
 - Added `rayon` for parallel processing
 
+## [0.3.2] - 2026-08-14
+
+### Dependencies
+
+- Updated `clap`, `globset`, `rayon`, and `tempfile` to latest compatible versions
+- Removed unused `colored` dependency
+
 ## [0.3.1] - 2026-02-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,16 +130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,10 +172,9 @@ dependencies = [
 
 [[package]]
 name = "ewc"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
- "colored",
  "globset",
  "rayon",
  "tempfile",
@@ -234,12 +223,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ewc"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "Enhanced Word Count - A modern alternative to wc"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         in {
           default = pkgs.rustPlatform.buildRustPackage {
             pname = "ewc";
-            version = "0.3.1";
+            version = "0.3.2";
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
             # Skip integration tests in Nix sandbox (requires filesystem access)


### PR DESCRIPTION
## Summary
- Version bump for the dependency updates/cleanup shipped in #18 and #19: clap/globset/rayon/tempfile bumped to latest compatible, unused `colored` dependency removed. No behavior change.
- Bumps `Cargo.toml`, `Cargo.lock` (package version), `flake.nix`, and `CHANGELOG.md`.

## Test plan
- [x] `cargo test` (37 passed)
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`