### PR TITLE
perf(counter): fuse Count::from_content into a single pass over content

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -22,11 +22,53 @@ pub struct Count {
 
 impl Count {
     pub fn from_content(content: &str) -> Self {
+        let mut lines: u64 = 0;
+        let mut words: u64 = 0;
+        let mut max_line_length: u64 = 0;
+        let mut current_line_len: u64 = 0;
+        let mut line_has_content = false;
+        let mut in_word = false;
+        // Mirrors str::lines(), which trims a lone '\r' immediately before '\n';
+        // track whether the previous char was '\r' so its byte can be backed out
+        // of the line length once we know a following '\n' makes it a CRLF pair.
+        let mut prev_was_cr = false;
+
+        for ch in content.chars() {
+            if ch == '\n' {
+                if prev_was_cr {
+                    current_line_len -= 1;
+                }
+                lines += 1;
+                max_line_length = max_line_length.max(current_line_len);
+                current_line_len = 0;
+                line_has_content = false;
+                in_word = false;
+                prev_was_cr = false;
+                continue;
+            }
+
+            current_line_len += ch.len_utf8() as u64;
+            line_has_content = true;
+            prev_was_cr = ch == '\r';
+
+            if ch.is_whitespace() {
+                in_word = false;
+            } else if !in_word {
+                in_word = true;
+                words += 1;
+            }
+        }
+
+        if line_has_content {
+            lines += 1;
+            max_line_length = max_line_length.max(current_line_len);
+        }
+
         Self {
-            lines: content.lines().count() as u64,
-            words: content.split_whitespace().count() as u64,
+            lines,
+            words,
             bytes: content.len() as u64,
-            max_line_length: content.lines().map(|l| l.len()).max().unwrap_or(0) as u64,
+            max_line_length,
         }
     }
 }
@@ -267,6 +309,28 @@ mod tests {
     fn count_max_line_length_varies() {
         let count = Count::from_content("short\nlonger line here\nmed");
         assert_eq!(count.max_line_length, 16); // "longer line here"
+    }
+
+    #[test]
+    fn count_crlf_line_endings() {
+        // The trailing '\r' of a CRLF pair must not count toward line length,
+        // matching str::lines() semantics.
+        let count = Count::from_content("ab\r\nc\r\n");
+        assert_eq!(count.lines, 2);
+        assert_eq!(count.words, 2);
+        assert_eq!(count.bytes, 7);
+        assert_eq!(count.max_line_length, 2); // "ab", not "ab\r"
+    }
+
+    #[test]
+    fn count_lone_carriage_return_is_whitespace_not_newline() {
+        // A '\r' not followed by '\n' stays on the same line (str::lines()
+        // only splits on '\n'/'\r\n'), but split_whitespace() still treats
+        // it as a word separator.
+        let count = Count::from_content("foo\rbar");
+        assert_eq!(count.lines, 1);
+        assert_eq!(count.words, 2);
+        assert_eq!(count.max_line_length, 7);
     }
 
     #[test]

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -26,7 +26,6 @@ impl Count {
         let mut words: u64 = 0;
         let mut max_line_length: u64 = 0;
         let mut current_line_len: u64 = 0;
-        let mut line_has_content = false;
         let mut in_word = false;
         // Mirrors str::lines(), which trims a lone '\r' immediately before '\n';
         // track whether the previous char was '\r' so its byte can be backed out
@@ -41,14 +40,12 @@ impl Count {
                 lines += 1;
                 max_line_length = max_line_length.max(current_line_len);
                 current_line_len = 0;
-                line_has_content = false;
                 in_word = false;
                 prev_was_cr = false;
                 continue;
             }
 
             current_line_len += ch.len_utf8() as u64;
-            line_has_content = true;
             prev_was_cr = ch == '\r';
 
             if ch.is_whitespace() {
@@ -59,7 +56,10 @@ impl Count {
             }
         }
 
-        if line_has_content {
+        // A trailing partial line (content that doesn't end in '\n') still
+        // counts, matching str::lines(); current_line_len > 0 iff such a line
+        // exists, since every non-'\n' char adds at least one byte to it.
+        if current_line_len > 0 {
             lines += 1;
             max_line_length = max_line_length.max(current_line_len);
         }


### PR DESCRIPTION
## Summary
- `Count::from_content` made three independent full scans of every file's content: `lines().count()`, `split_whitespace().count()`, and a second `lines().map(len).max()`. This is the hot loop called once per file from the rayon pool.
- Replaced with a single char-by-char state machine that tracks line count, in-word state, and max line length together in one pass. Byte count stays `content.len()` (already O(1), never a real scan).
- The fused loop replicates `str::lines()`'s CRLF handling exactly: a lone `\r` immediately before `\n` is trimmed from the line before measuring its length, so CRLF-terminated files aren't over-counted. Covered by new tests.

## Test plan
- [x] `cargo test` (68 unit + 37 integration, incl. 2 new CRLF/lone-`\r` edge case tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`

Closes #6