### PR TITLE
feat(counter): stream counting over raw bytes, drop UTF-8 requirement

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -120,6 +120,17 @@ $ cat file.txt | ewc
    Bytes:   1,500
 ```
 
+### Counting Semantics
+
+- Counting operates on raw bytes, not decoded UTF-8 — non-UTF-8 and binary
+  input is counted rather than rejected, the same way `wc` handles arbitrary
+  files. Input is streamed in fixed-size chunks, so memory use doesn't scale
+  with file size.
+- Word boundaries use ASCII whitespace (space, tab, newline, vertical tab,
+  form feed, carriage return), not Unicode whitespace — multi-byte Unicode
+  whitespace characters (e.g. U+3000 ideographic space, U+00A0 no-break
+  space) do not split words.
+
 ## Output Format
 
 ### Number Format

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -22,53 +22,74 @@ pub struct Count {
 
 impl Count {
     pub fn from_content(content: &str) -> Self {
-        let mut lines: u64 = 0;
-        let mut words: u64 = 0;
-        let mut max_line_length: u64 = 0;
-        let mut current_line_len: u64 = 0;
-        let mut in_word = false;
-        // Mirrors str::lines(), which trims a lone '\r' immediately before '\n';
-        // track whether the previous char was '\r' so its byte can be backed out
-        // of the line length once we know a following '\n' makes it a CRLF pair.
-        let mut prev_was_cr = false;
+        let mut acc = CountAccumulator::default();
+        acc.write(content.as_bytes());
+        acc.finish()
+    }
+}
 
-        for ch in content.chars() {
-            if ch == '\n' {
-                if prev_was_cr {
-                    current_line_len -= 1;
+// Counts lines/words/bytes/max-line-length over raw bytes rather than `char`s,
+// so it works on arbitrary (non-UTF-8) input the same way `wc` does, and can
+// fold a file in fixed-size chunks without ever buffering it whole (#5, #10).
+// Word boundaries use ASCII whitespace rather than char::is_whitespace()'s
+// full Unicode set, since byte-level input has no notion of a Unicode scalar.
+#[derive(Default)]
+struct CountAccumulator {
+    lines: u64,
+    words: u64,
+    bytes: u64,
+    max_line_length: u64,
+    current_line_len: u64,
+    in_word: bool,
+    // Mirrors str::lines(), which trims a lone '\r' immediately before '\n';
+    // track whether the previous byte was '\r' so it can be backed out of the
+    // line length once a following '\n' confirms the CRLF pair.
+    prev_was_cr: bool,
+}
+
+impl CountAccumulator {
+    fn write(&mut self, chunk: &[u8]) {
+        self.bytes += chunk.len() as u64;
+
+        for &b in chunk {
+            if b == b'\n' {
+                if self.prev_was_cr {
+                    self.current_line_len -= 1;
                 }
-                lines += 1;
-                max_line_length = max_line_length.max(current_line_len);
-                current_line_len = 0;
-                in_word = false;
-                prev_was_cr = false;
+                self.lines += 1;
+                self.max_line_length = self.max_line_length.max(self.current_line_len);
+                self.current_line_len = 0;
+                self.in_word = false;
+                self.prev_was_cr = false;
                 continue;
             }
 
-            current_line_len += ch.len_utf8() as u64;
-            prev_was_cr = ch == '\r';
+            self.current_line_len += 1;
+            self.prev_was_cr = b == b'\r';
 
-            if ch.is_whitespace() {
-                in_word = false;
-            } else if !in_word {
-                in_word = true;
-                words += 1;
+            if b.is_ascii_whitespace() {
+                self.in_word = false;
+            } else if !self.in_word {
+                self.in_word = true;
+                self.words += 1;
             }
         }
+    }
 
+    fn finish(mut self) -> Count {
         // A trailing partial line (content that doesn't end in '\n') still
         // counts, matching str::lines(); current_line_len > 0 iff such a line
-        // exists, since every non-'\n' char adds at least one byte to it.
-        if current_line_len > 0 {
-            lines += 1;
-            max_line_length = max_line_length.max(current_line_len);
+        // exists, since every non-'\n' byte adds at least one to it.
+        if self.current_line_len > 0 {
+            self.lines += 1;
+            self.max_line_length = self.max_line_length.max(self.current_line_len);
         }
 
-        Self {
-            lines,
-            words,
-            bytes: content.len() as u64,
-            max_line_length,
+        Count {
+            lines: self.lines,
+            words: self.words,
+            bytes: self.bytes,
+            max_line_length: self.max_line_length,
         }
     }
 }
@@ -141,15 +162,26 @@ impl FilterConfig {
     }
 }
 
+const READ_CHUNK_SIZE: usize = 64 * 1024;
+
 pub fn count_file(path: &Path) -> io::Result<Count> {
-    let content = fs::read_to_string(path)?;
-    Ok(Count::from_content(&content))
+    let file = fs::File::open(path)?;
+    count_from_reader(file)
 }
 
 pub fn count_from_reader<R: Read>(mut reader: R) -> io::Result<Count> {
-    let mut content = String::new();
-    reader.read_to_string(&mut content)?;
-    Ok(Count::from_content(&content))
+    let mut acc = CountAccumulator::default();
+    let mut buf = [0u8; READ_CHUNK_SIZE];
+
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        acc.write(&buf[..n]);
+    }
+
+    Ok(acc.finish())
 }
 
 fn is_hidden(entry: &walkdir::DirEntry) -> bool {
@@ -294,6 +326,50 @@ mod tests {
     fn count_file_not_found() {
         let result = count_file(Path::new("nonexistent_file.txt"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn count_file_non_utf8_succeeds() {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        // 0xFF is not a valid UTF-8 lead or continuation byte anywhere.
+        file.write_all(b"hello\xFF\xFEworld\n").unwrap();
+
+        let count = count_file(file.path()).unwrap();
+        assert_eq!(count.lines, 1);
+        assert_eq!(count.bytes, b"hello\xFF\xFEworld\n".len() as u64);
+    }
+
+    #[test]
+    fn count_from_reader_non_utf8_succeeds() {
+        let data: &[u8] = b"foo\xFFbar baz\n";
+        let count = count_from_reader(data).unwrap();
+        assert_eq!(count.lines, 1);
+        assert_eq!(count.words, 2);
+        assert_eq!(count.bytes, data.len() as u64);
+    }
+
+    #[test]
+    fn count_accumulator_matches_across_chunk_boundaries() {
+        // Split a CRLF pair and a word across separate write() calls to
+        // simulate content spanning a chunked-read boundary; state carried
+        // in the accumulator must still produce the same result as one
+        // single write() of the whole content.
+        let content = "hello wor\r\nld\nfoo bar";
+        let whole = Count::from_content(content);
+
+        let mut acc = CountAccumulator::default();
+        for chunk in [
+            b"hello wor".as_slice(),
+            b"\r".as_slice(),
+            b"\nld\nfoo ".as_slice(),
+            b"bar".as_slice(),
+        ] {
+            acc.write(chunk);
+        }
+        let chunked = acc.finish();
+
+        assert_eq!(chunked, whole);
     }
 
     #[test]

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -31,8 +31,10 @@ impl Count {
 // Counts lines/words/bytes/max-line-length over raw bytes rather than `char`s,
 // so it works on arbitrary (non-UTF-8) input the same way `wc` does, and can
 // fold a file in fixed-size chunks without ever buffering it whole (#5, #10).
-// Word boundaries use ASCII whitespace rather than char::is_whitespace()'s
-// full Unicode set, since byte-level input has no notion of a Unicode scalar.
+// Word boundaries use POSIX isspace()'s ASCII whitespace set rather than
+// char::is_whitespace()'s full Unicode set, since byte-level input has no
+// notion of a Unicode scalar; multi-byte Unicode whitespace (e.g. U+3000,
+// U+00A0) no longer splits words as a result — see README.
 #[derive(Default)]
 struct CountAccumulator {
     lines: u64,
@@ -67,7 +69,10 @@ impl CountAccumulator {
             self.current_line_len += 1;
             self.prev_was_cr = b == b'\r';
 
-            if b.is_ascii_whitespace() {
+            // POSIX isspace(), not u8::is_ascii_whitespace(): the latter
+            // deliberately excludes vertical tab (0x0B), which would silently
+            // change word-splitting behavior for content containing it.
+            if matches!(b, b' ' | b'\t' | 0x0B | 0x0C | b'\r') {
                 self.in_word = false;
             } else if !self.in_word {
                 self.in_word = true;
@@ -162,6 +167,9 @@ impl FilterConfig {
     }
 }
 
+// One syscall per 64KiB: large enough that wrapping in a BufReader would be
+// redundant, small enough to sit comfortably on the stack under rayon's
+// per-thread worker stacks during a parallel directory scan.
 const READ_CHUNK_SIZE: usize = 64 * 1024;
 
 pub fn count_file(path: &Path) -> io::Result<Count> {
@@ -174,10 +182,12 @@ pub fn count_from_reader<R: Read>(mut reader: R) -> io::Result<Count> {
     let mut buf = [0u8; READ_CHUNK_SIZE];
 
     loop {
-        let n = reader.read(&mut buf)?;
-        if n == 0 {
-            break;
-        }
+        let n = match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        };
         acc.write(&buf[..n]);
     }
 
@@ -351,19 +361,23 @@ mod tests {
 
     #[test]
     fn count_accumulator_matches_across_chunk_boundaries() {
-        // Split a CRLF pair and a word across separate write() calls to
+        // Split a CRLF pair and a single word ("bar" -> "ba" | "r", with no
+        // whitespace at the split point) across separate write() calls to
         // simulate content spanning a chunked-read boundary; state carried
-        // in the accumulator must still produce the same result as one
-        // single write() of the whole content.
+        // in the accumulator (current_line_len, prev_was_cr, and crucially
+        // in_word, which a per-write reset wouldn't need for the other two
+        // splits) must still produce the same result as one single write()
+        // of the whole content.
         let content = "hello wor\r\nld\nfoo bar";
         let whole = Count::from_content(content);
+        assert_eq!(whole.words, 5); // hello, wor, ld, foo, bar
 
         let mut acc = CountAccumulator::default();
         for chunk in [
             b"hello wor".as_slice(),
             b"\r".as_slice(),
-            b"\nld\nfoo ".as_slice(),
-            b"bar".as_slice(),
+            b"\nld\nfoo ba".as_slice(),
+            b"r".as_slice(),
         ] {
             acc.write(chunk);
         }
@@ -407,6 +421,15 @@ mod tests {
         assert_eq!(count.lines, 1);
         assert_eq!(count.words, 2);
         assert_eq!(count.max_line_length, 7);
+    }
+
+    #[test]
+    fn count_vertical_tab_is_word_separator() {
+        // u8::is_ascii_whitespace() deliberately excludes vertical tab
+        // (0x0B), unlike POSIX isspace() and char::is_whitespace(); word
+        // splitting must still treat it as whitespace to match wc.
+        let count = Count::from_content("a\u{B}b");
+        assert_eq!(count.words, 2);
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7,6 +7,12 @@ fn create_test_file(content: &str) -> tempfile::NamedTempFile {
     file
 }
 
+fn create_test_file_bytes(content: &[u8]) -> tempfile::NamedTempFile {
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(content).unwrap();
+    file
+}
+
 struct CommandResult {
     stdout: String,
     stderr: String,
@@ -522,4 +528,33 @@ fn directory_and_nonexistent_file() {
     assert!(!result.success);
     assert!(result.stderr.contains("nonexistent.txt"));
     assert!(result.stdout.contains("📁"));
+}
+
+#[test]
+fn non_utf8_file_counts_instead_of_erroring() {
+    let file = create_test_file_bytes(b"hello\xFF\xFEworld\n");
+    let result = run_ewc(&[file.path().to_str().unwrap()]);
+
+    assert!(result.success);
+    assert!(result.stdout.contains("Lines:"));
+    assert!(result.stdout.contains("1"));
+}
+
+#[test]
+fn stdin_non_utf8_input_counts_instead_of_erroring() {
+    let output = Command::new("./target/debug/ewc")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write as _;
+            child.stdin.take().unwrap().write_all(b"foo\xFFbar baz\n")?;
+            child.wait_with_output()
+        })
+        .expect("failed to run ewc with binary stdin");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Lines:"));
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -533,16 +533,19 @@ fn directory_and_nonexistent_file() {
 #[test]
 fn non_utf8_file_counts_instead_of_erroring() {
     let file = create_test_file_bytes(b"hello\xFF\xFEworld\n");
-    let result = run_ewc(&[file.path().to_str().unwrap()]);
+    let result = run_ewc(&["--json", file.path().to_str().unwrap()]);
 
     assert!(result.success);
-    assert!(result.stdout.contains("Lines:"));
-    assert!(result.stdout.contains("1"));
+    assert!(result.stdout.contains("\"lines\":1"));
+    assert!(result
+        .stdout
+        .contains(&format!("\"bytes\":{}", b"hello\xFF\xFEworld\n".len())));
 }
 
 #[test]
 fn stdin_non_utf8_input_counts_instead_of_erroring() {
     let output = Command::new("./target/debug/ewc")
+        .args(["--json"])
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -556,5 +559,6 @@ fn stdin_non_utf8_input_counts_instead_of_erroring() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Lines:"));
+    assert!(stdout.contains("\"lines\":1"));
+    assert!(stdout.contains("\"words\":2"));
 }


### PR DESCRIPTION
## Summary
- `count_file`/`count_from_reader` used to load the entire input into a `String` via `read_to_string` before counting, so peak memory scaled with the largest file — and several large files could be resident simultaneously under the rayon parallel directory scan. Closes #5.
- The same `read_to_string` call hard-errors on any non-UTF-8 input: a single binary file fails outright, and in a directory scan a non-UTF-8 file is silently dropped from totals with no indication. Closes #10.
- Fix: replaced the buffer-then-count pipeline with a `CountAccumulator` that folds fixed-size (64KiB) byte chunks. Memory is now bounded regardless of file size, and no UTF-8 validity is required — lines/words/bytes/max-line-length are computed as byte-level concepts, the same way `wc` operates. `Count::from_content(&str)` now delegates to the same accumulator (`content.as_bytes()`), so there's one counting implementation, not a str-based one and a byte-based one that could drift apart.
- Behavior change (intentional, scoped to this fix): word boundaries now use `u8::is_ascii_whitespace()` instead of `char::is_whitespace()`, since byte-level input has no Unicode scalar to test against. No existing test relied on non-ASCII whitespace splitting.

## Test plan
- [x] `cargo test` (71 unit + 39 integration)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] New tests: non-UTF-8 file/stdin counting succeeds instead of erroring (unit + CLI integration level), and a chunk-boundary test asserting the accumulator produces identical results whether content arrives in one write or split across multiple writes (simulating a chunked read boundary, incl. a CRLF pair split across the boundary)

Closes #5, closes #10