### PR TITLE
fix(counter): report skipped directory entries instead of dropping them

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -12,6 +12,14 @@ pub struct FileEntry {
     pub count: Count,
 }
 
+/// A directory-scan entry (a walked path, or a file within it) that could
+/// not be counted — permission denied, vanished mid-walk, or any other I/O
+/// failure — along with the error that caused it to be skipped.
+pub struct SkippedEntry {
+    pub path: PathBuf,
+    pub error: String,
+}
+
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
 pub struct Count {
     pub lines: u64,
@@ -206,62 +214,102 @@ fn matches_glob(glob_set: &GlobSet, relative_path: &Path) -> bool {
     glob_set.is_match(&*path_str) || glob_set.is_match(relative_path)
 }
 
-fn walk_directory(path: &Path, config: &FilterConfig) -> io::Result<Vec<PathBuf>> {
+// Symlinks inside a scanned directory are intentionally not followed:
+// walkdir does not follow them by default, and this matches classic `wc`'s
+// behavior of only counting regular files it walks into directly.
+fn walk_directory(
+    path: &Path,
+    config: &FilterConfig,
+) -> io::Result<(Vec<PathBuf>, Vec<SkippedEntry>)> {
     let exclude_set = FilterConfig::build_globset(&config.exclude_patterns)?;
     let include_set = FilterConfig::build_globset(&config.include_patterns)?;
     let has_include_patterns = !config.include_patterns.is_empty();
 
-    let entries = WalkDir::new(path)
+    let mut entries = Vec::new();
+    let mut skipped = Vec::new();
+
+    for entry in WalkDir::new(path)
         .into_iter()
         .filter_entry(|e| e.depth() == 0 || config.include_hidden || !is_hidden(e))
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().is_file())
-        .filter_map(|entry| {
-            let file_path = entry.path();
-            let relative_path = file_path.strip_prefix(path).unwrap_or(file_path);
-
-            if matches_glob(&exclude_set, relative_path) {
-                return None;
+    {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                let entry_path = e
+                    .path()
+                    .map_or_else(|| path.to_path_buf(), Path::to_path_buf);
+                skipped.push(SkippedEntry {
+                    path: entry_path,
+                    error: e.to_string(),
+                });
+                continue;
             }
+        };
 
-            if has_include_patterns && !matches_glob(&include_set, relative_path) {
-                return None;
-            }
+        if !entry.file_type().is_file() {
+            continue;
+        }
 
-            Some(file_path.to_path_buf())
-        })
-        .collect();
+        let file_path = entry.path();
+        let relative_path = file_path.strip_prefix(path).unwrap_or(file_path);
 
-    Ok(entries)
+        if matches_glob(&exclude_set, relative_path) {
+            continue;
+        }
+        if has_include_patterns && !matches_glob(&include_set, relative_path) {
+            continue;
+        }
+
+        entries.push(file_path.to_path_buf());
+    }
+
+    Ok((entries, skipped))
 }
 
-pub fn count_directory(path: &Path, config: &FilterConfig) -> io::Result<(Count, usize)> {
-    let (entries, total) = count_directory_detailed(path, config)?;
-    Ok((total, entries.len()))
+pub fn count_directory(
+    path: &Path,
+    config: &FilterConfig,
+) -> io::Result<(Count, usize, Vec<SkippedEntry>)> {
+    let (entries, total, skipped) = count_directory_detailed(path, config)?;
+    Ok((total, entries.len(), skipped))
 }
 
 pub fn count_directory_detailed(
     path: &Path,
     config: &FilterConfig,
-) -> io::Result<(Vec<FileEntry>, Count)> {
-    let file_paths = walk_directory(path, config)?;
+) -> io::Result<(Vec<FileEntry>, Count, Vec<SkippedEntry>)> {
+    let (file_paths, mut skipped) = walk_directory(path, config)?;
 
-    // Parallel file counting with rayon
-    let mut entries: Vec<FileEntry> = file_paths
+    // Parallel file counting with rayon; failures are collected rather than
+    // dropped so directory totals are never silently short (#11).
+    let results: Vec<Result<FileEntry, SkippedEntry>> = file_paths
         .par_iter()
-        .filter_map(|file_path| {
-            count_file(file_path).ok().map(|count| FileEntry {
-                path: file_path.clone(),
-                count,
-            })
+        .map(|file_path| {
+            count_file(file_path)
+                .map(|count| FileEntry {
+                    path: file_path.clone(),
+                    count,
+                })
+                .map_err(|e| SkippedEntry {
+                    path: file_path.clone(),
+                    error: e.to_string(),
+                })
         })
         .collect();
+
+    let mut entries = Vec::with_capacity(results.len());
+    for result in results {
+        match result {
+            Ok(entry) => entries.push(entry),
+            Err(entry) => skipped.push(entry),
+        }
+    }
 
     // Sort for deterministic output
     entries.sort_by(|a, b| a.path.cmp(&b.path));
 
     let total = entries.iter().map(|e| e.count).sum();
-    Ok((entries, total))
+    Ok((entries, total, skipped))
 }
 
 #[cfg(test)]
@@ -497,10 +545,55 @@ mod tests {
 
         let result = count_directory(dir.path(), &default_config());
         assert!(result.is_ok());
-        let (count, file_count) = result.unwrap();
+        let (count, file_count, skipped) = result.unwrap();
+        assert!(skipped.is_empty());
         assert_eq!(file_count, 1);
         assert_eq!(count.lines, 1);
         assert_eq!(count.words, 2);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn count_directory_reports_unreadable_file_as_skipped() {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+
+        let readable = dir.path().join("readable.txt");
+        let mut f = std::fs::File::create(&readable).unwrap();
+        writeln!(f, "hello world").unwrap();
+
+        let unreadable = dir.path().join("unreadable.txt");
+        std::fs::write(&unreadable, "secret").unwrap();
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = count_directory(dir.path(), &default_config());
+        let restore = || {
+            // Restore permissions so tempdir cleanup can remove the file.
+            let _ = std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o644));
+        };
+
+        let (count, file_count, skipped) = match result {
+            Ok(v) => v,
+            Err(e) => {
+                restore();
+                panic!("count_directory failed: {e}");
+            }
+        };
+        restore();
+
+        // Running as root (some CI/sandbox environments) bypasses permission
+        // checks entirely, in which case there's nothing to assert here.
+        if skipped.is_empty() && file_count == 2 {
+            return;
+        }
+
+        assert_eq!(file_count, 1);
+        assert_eq!(count.lines, 1);
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0].path, unreadable);
+        assert!(!skipped[0].error.is_empty());
     }
 
     #[test]
@@ -518,7 +611,8 @@ mod tests {
 
         let result = count_directory(dir.path(), &default_config());
         assert!(result.is_ok());
-        let (count, file_count) = result.unwrap();
+        let (count, file_count, skipped) = result.unwrap();
+        assert!(skipped.is_empty());
         assert_eq!(file_count, 2);
         assert_eq!(count.lines, 2);
         assert_eq!(count.words, 2);
@@ -543,7 +637,8 @@ mod tests {
 
         let result = count_directory(dir.path(), &default_config());
         assert!(result.is_ok());
-        let (count, file_count) = result.unwrap();
+        let (count, file_count, skipped) = result.unwrap();
+        assert!(skipped.is_empty());
         assert_eq!(file_count, 2);
         assert_eq!(count.lines, 2);
         assert_eq!(count.words, 3); // "root" + "nested file"
@@ -566,7 +661,8 @@ mod tests {
 
         let result = count_directory(dir.path(), &default_config());
         assert!(result.is_ok());
-        let (count, file_count) = result.unwrap();
+        let (count, file_count, skipped) = result.unwrap();
+        assert!(skipped.is_empty());
         assert_eq!(file_count, 1); // Only visible file
         assert_eq!(count.words, 1); // Only "visible"
     }
@@ -590,7 +686,8 @@ mod tests {
 
         let result = count_directory(dir.path(), &default_config());
         assert!(result.is_ok());
-        let (count, file_count) = result.unwrap();
+        let (count, file_count, skipped) = result.unwrap();
+        assert!(skipped.is_empty());
         assert_eq!(file_count, 1); // Only visible file
         assert_eq!(count.words, 1); // Only "visible"
     }
@@ -612,7 +709,8 @@ mod tests {
 
         let result = count_directory(dir.path(), &config_with_hidden());
         assert!(result.is_ok());
-        let (count, file_count) = result.unwrap();
+        let (count, file_count, skipped) = result.unwrap();
+        assert!(skipped.is_empty());
         assert_eq!(file_count, 2); // Both files
         assert_eq!(count.words, 2); // "visible" + "hidden"
     }
@@ -636,7 +734,8 @@ mod tests {
 
         let result = count_directory(dir.path(), &config_with_hidden());
         assert!(result.is_ok());
-        let (count, file_count) = result.unwrap();
+        let (count, file_count, skipped) = result.unwrap();
+        assert!(skipped.is_empty());
         assert_eq!(file_count, 2); // Both files
         assert_eq!(count.words, 4); // "visible" + "nested in hidden"
     }
@@ -656,7 +755,8 @@ mod tests {
 
         let result = count_directory_detailed(dir.path(), &default_config());
         assert!(result.is_ok());
-        let (entries, total) = result.unwrap();
+        let (entries, total, skipped) = result.unwrap();
+        assert!(skipped.is_empty());
 
         assert_eq!(entries.len(), 2);
         assert_eq!(total.lines, 2);
@@ -674,7 +774,7 @@ mod tests {
 
         let result = count_directory_detailed(dir.path(), &default_config());
         assert!(result.is_ok());
-        let (entries, _) = result.unwrap();
+        let (entries, _, _) = result.unwrap();
 
         // Should be sorted alphabetically
         assert!(entries[0].path.to_string_lossy().contains("a_file"));
@@ -694,7 +794,8 @@ mod tests {
         let config = FilterConfig::new(false, vec!["*.md".to_string()], vec![]);
         let result = count_directory(dir.path(), &config);
         assert!(result.is_ok());
-        let (count, file_count) = result.unwrap();
+        let (count, file_count, skipped) = result.unwrap();
+        assert!(skipped.is_empty());
         assert_eq!(file_count, 2); // .rs and .txt only
         assert_eq!(count.words, 3); // "rust code" + "text"
     }
@@ -710,7 +811,8 @@ mod tests {
         let config = FilterConfig::new(false, vec![], vec!["*.rs".to_string()]);
         let result = count_directory(dir.path(), &config);
         assert!(result.is_ok());
-        let (count, file_count) = result.unwrap();
+        let (count, file_count, skipped) = result.unwrap();
+        assert!(skipped.is_empty());
         assert_eq!(file_count, 1); // .rs only
         assert_eq!(count.words, 2); // "rust code"
     }
@@ -732,7 +834,8 @@ mod tests {
         );
         let result = count_directory(dir.path(), &config);
         assert!(result.is_ok());
-        let (count, file_count) = result.unwrap();
+        let (count, file_count, skipped) = result.unwrap();
+        assert!(skipped.is_empty());
         assert_eq!(file_count, 2); // main.rs and lib.rs only
         assert_eq!(count.words, 2); // "main" + "lib"
     }
@@ -750,7 +853,8 @@ mod tests {
         let config = FilterConfig::new(false, vec!["target/*".to_string()], vec![]);
         let result = count_directory(dir.path(), &config);
         assert!(result.is_ok());
-        let (count, file_count) = result.unwrap();
+        let (count, file_count, skipped) = result.unwrap();
+        assert!(skipped.is_empty());
         assert_eq!(file_count, 1); // Only root.txt
         assert_eq!(count.words, 1); // "root"
     }
@@ -771,7 +875,8 @@ mod tests {
         );
         let result = count_directory(dir.path(), &config);
         assert!(result.is_ok());
-        let (count, file_count) = result.unwrap();
+        let (count, file_count, skipped) = result.unwrap();
+        assert!(skipped.is_empty());
         assert_eq!(file_count, 2); // .rs and .txt only
         assert_eq!(count.words, 2); // "rust" + "text"
     }

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -238,9 +238,16 @@ fn walk_directory(
                 let entry_path = e
                     .path()
                     .map_or_else(|| path.to_path_buf(), Path::to_path_buf);
+                // walkdir::Error's Display already includes the path when one
+                // is available ("IO error for operation on {path}: {err}"),
+                // so fall back to the inner io::Error's message to avoid
+                // printing the path twice in the reported warning line.
+                let error = e
+                    .io_error()
+                    .map_or_else(|| e.to_string(), ToString::to_string);
                 skipped.push(SkippedEntry {
                     path: entry_path,
-                    error: e.to_string(),
+                    error,
                 });
                 continue;
             }
@@ -305,8 +312,10 @@ pub fn count_directory_detailed(
         }
     }
 
-    // Sort for deterministic output
+    // Sort for deterministic output; walk order is OS-dependent, and the
+    // rayon phase above preserves the (already-walked) file_paths order.
     entries.sort_by(|a, b| a.path.cmp(&b.path));
+    skipped.sort_by(|a, b| a.path.cmp(&b.path));
 
     let total = entries.iter().map(|e| e.count).sum();
     Ok((entries, total, skipped))
@@ -569,8 +578,9 @@ mod tests {
         std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
 
         let result = count_directory(dir.path(), &default_config());
+        // Not required for tempdir cleanup (unlinking only needs write access
+        // to the parent directory), but restoring is good hygiene regardless.
         let restore = || {
-            // Restore permissions so tempdir cleanup can remove the file.
             let _ = std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o644));
         };
 
@@ -593,6 +603,55 @@ mod tests {
         assert_eq!(count.lines, 1);
         assert_eq!(skipped.len(), 1);
         assert_eq!(skipped[0].path, unreadable);
+        assert!(!skipped[0].error.is_empty());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn count_directory_reports_unreadable_subdirectory_as_skipped() {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+
+        let readable = dir.path().join("readable.txt");
+        let mut f = std::fs::File::create(&readable).unwrap();
+        writeln!(f, "hello world").unwrap();
+
+        // Without the execute bit, walkdir cannot read_dir into this
+        // subdirectory at all — this exercises the walk-phase error path
+        // (layer 1), distinct from a per-file read failure (layer 2), which
+        // count_directory_reports_unreadable_file_as_skipped covers.
+        let locked_subdir = dir.path().join("locked");
+        std::fs::create_dir(&locked_subdir).unwrap();
+        std::fs::write(locked_subdir.join("inside.txt"), "unreachable").unwrap();
+        std::fs::set_permissions(&locked_subdir, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = count_directory(dir.path(), &default_config());
+        let restore = || {
+            let _ =
+                std::fs::set_permissions(&locked_subdir, std::fs::Permissions::from_mode(0o755));
+        };
+
+        let (count, file_count, skipped) = match result {
+            Ok(v) => v,
+            Err(e) => {
+                restore();
+                panic!("count_directory failed: {e}");
+            }
+        };
+        restore();
+
+        // Running as root (some CI/sandbox environments) bypasses permission
+        // checks entirely, in which case there's nothing to assert here.
+        if skipped.is_empty() && file_count == 2 {
+            return;
+        }
+
+        assert_eq!(file_count, 1);
+        assert_eq!(count.lines, 1);
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0].path, locked_subdir);
         assert!(!skipped[0].error.is_empty());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::process;
 use ewc::cli::Args;
 use ewc::counter::{
     count_directory, count_directory_detailed, count_file, count_from_reader, Count, FilterConfig,
+    SkippedEntry,
 };
 use ewc::output::{
     format_compact_output, format_compact_total, format_json_multiple, format_json_single,
@@ -18,19 +19,35 @@ const WARNING_ICON: &str = "\u{26A0}\u{FE0F}";
 struct ProcessResult {
     count: Count,
     file_count: usize,
+    skipped: Vec<SkippedEntry>,
 }
 
 fn process_path(path: &Path, config: &FilterConfig) -> io::Result<ProcessResult> {
     if path.is_dir() {
-        let (count, file_count) = count_directory(path, config)?;
-        Ok(ProcessResult { count, file_count })
+        let (count, file_count, skipped) = count_directory(path, config)?;
+        Ok(ProcessResult {
+            count,
+            file_count,
+            skipped,
+        })
     } else {
         let count = count_file(path)?;
         Ok(ProcessResult {
             count,
             file_count: 1,
+            skipped: Vec::new(),
         })
     }
+}
+
+/// Prints one warning line per skipped entry, matching the existing
+/// top-level-failure style. Returns whether anything was skipped, so callers
+/// can fold it into the process's exit code.
+fn report_skipped(skipped: &[SkippedEntry]) -> bool {
+    for entry in skipped {
+        eprintln!("{WARNING_ICON}  {}: {}", entry.path.display(), entry.error);
+    }
+    !skipped.is_empty()
 }
 
 fn create_filter_config(args: &Args) -> FilterConfig {
@@ -92,6 +109,10 @@ fn run_json_mode(args: &Args) {
             continue;
         };
 
+        if report_skipped(&result.skipped) {
+            has_error = true;
+        }
+
         let is_directory = path.is_dir();
         results.push(JsonFileResult {
             name: file.clone(),
@@ -127,8 +148,12 @@ fn run_normal_mode(args: &Args) {
 
         if path.is_dir() && args.verbose {
             match count_directory_detailed(path, &config) {
-                Ok((entries, dir_total)) => {
+                Ok((entries, dir_total, skipped)) => {
                     println!("{}", format_verbose_output(&entries, &dir_total, args));
+
+                    if report_skipped(&skipped) {
+                        has_error = true;
+                    }
 
                     total_count += dir_total;
                     total_file_count += entries.len();
@@ -157,6 +182,10 @@ fn run_normal_mode(args: &Args) {
                         format_output(file, &result.count, kind, args)
                     };
                     println!("{output}");
+
+                    if report_skipped(&result.skipped) {
+                        has_error = true;
+                    }
 
                     total_count += result.count;
                     total_file_count += result.file_count;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -562,3 +562,31 @@ fn stdin_non_utf8_input_counts_instead_of_erroring() {
     assert!(stdout.contains("\"lines\":1"));
     assert!(stdout.contains("\"words\":2"));
 }
+
+#[test]
+#[cfg(unix)]
+fn directory_scan_reports_unreadable_file_and_exits_nonzero() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("readable.txt"), "hello world\n").unwrap();
+    let unreadable = dir.path().join("unreadable.txt");
+    std::fs::write(&unreadable, "secret\n").unwrap();
+    std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let result = run_ewc(&[dir.path().to_str().unwrap()]);
+
+    // Restore permissions so the tempdir can be cleaned up.
+    let _ = std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o644));
+
+    if result.stdout.contains("(2 files)") {
+        // Running as root (some CI/sandbox environments) bypasses permission
+        // checks entirely; nothing to assert in that case.
+        return;
+    }
+
+    assert!(!result.success);
+    assert!(result.stderr.contains("unreadable.txt"));
+    // The readable file must still be counted, not silently dropped.
+    assert!(result.stdout.contains("(1 file)"));
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -576,7 +576,8 @@ fn directory_scan_reports_unreadable_file_and_exits_nonzero() {
 
     let result = run_ewc(&[dir.path().to_str().unwrap()]);
 
-    // Restore permissions so the tempdir can be cleaned up.
+    // Not required for tempdir cleanup (unlinking only needs write access to
+    // the parent directory), but restoring is good hygiene regardless.
     let _ = std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o644));
 
     if result.stdout.contains("(2 files)") {


### PR DESCRIPTION
## Summary
- `walk_directory` mapped walkdir errors (permission denied, a directory that disappears mid-walk) to `None`; `count_directory_detailed` converted per-file read failures to `None` via `.ok()`. Both silently pruned entries from a directory scan — the user got normal-looking output and exit code 0 while totals under-reported with no signal.
- `count_directory_detailed`/`count_directory` now also return a `Vec<SkippedEntry>` (path + error string) collecting both walk errors and per-file count failures. `main.rs` prints one warning-icon line per skipped entry (matching the existing top-level-failure style) and folds any skips into the process exit code, in both normal and `--json` mode.
- `walk_directory` rewritten from a `filter_map` chain to an explicit `for` loop, since routing errors into a side `Vec` alongside filtering/collecting successes doesn't fit the chain style used before.
- Documented (not changed) that symlinks inside a scanned directory aren't followed — matches walkdir's default and classic `wc`; the issue left this as documentation-or-fix, and following symlinks is a separate behavior change with its own tradeoffs (cycles, escaping the scan root).

## Test plan
- [x] `cargo test` (73 unit + 40 integration)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] New tests (Unix-only, `#[cfg(unix)]`, via `chmod 000`): a directory with one readable and one permission-denied file reports the unreadable one as skipped (unit level) and via the CLI exits nonzero with a stderr warning while still counting the readable file (integration level) — both gracefully no-op if run as root, where permission checks don't apply

Closes #11