### PR TITLE
fix(output): serialize JSON via serde_json instead of hand-rolled escaping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -114,7 +114,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -167,7 +167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -177,6 +177,8 @@ dependencies = [
  "clap",
  "globset",
  "rayon",
+ "serde",
+ "serde_json",
  "tempfile",
  "walkdir",
 ]
@@ -223,6 +225,12 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
@@ -331,7 +339,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -345,31 +353,45 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -390,6 +412,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,7 +432,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -439,7 +472,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -447,15 +480,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -467,71 +491,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ readme = "README.md"
 clap = { version = "4", features = ["derive"] }
 globset = "0.4"
 rayon = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 walkdir = "2"
 
 [dev-dependencies]

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,5 +1,6 @@
 use crate::cli::Args;
 use crate::counter::{Count, FileEntry};
+use serde::Serialize;
 
 pub enum OutputKind {
     File,
@@ -155,50 +156,89 @@ pub struct JsonFileResult {
     pub file_count: Option<usize>,
 }
 
-pub fn format_json_single(result: &JsonFileResult) -> String {
+#[derive(Serialize)]
+struct JsonFile<'a> {
+    file: &'a str,
+    max_line_length: u64,
+    lines: u64,
+    words: u64,
+    bytes: u64,
+}
+
+#[derive(Serialize)]
+struct JsonDirectory<'a> {
+    directory: &'a str,
+    file_count: usize,
+    max_line_length: u64,
+    lines: u64,
+    words: u64,
+    bytes: u64,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum JsonEntry<'a> {
+    File(JsonFile<'a>),
+    Directory(JsonDirectory<'a>),
+}
+
+#[derive(Serialize)]
+struct JsonTotal {
+    file_count: usize,
+    max_line_length: u64,
+    lines: u64,
+    words: u64,
+    bytes: u64,
+}
+
+#[derive(Serialize)]
+struct JsonMultiple<'a> {
+    files: Vec<JsonEntry<'a>>,
+    total: JsonTotal,
+}
+
+fn json_entry(result: &JsonFileResult) -> JsonEntry<'_> {
+    let count = &result.count;
     if result.is_directory {
-        format!(
-            r#"{{"directory":"{}","file_count":{},"max_line_length":{},"lines":{},"words":{},"bytes":{}}}"#,
-            escape_json(&result.name),
-            result.file_count.unwrap_or(0),
-            result.count.max_line_length,
-            result.count.lines,
-            result.count.words,
-            result.count.bytes
-        )
+        JsonEntry::Directory(JsonDirectory {
+            directory: &result.name,
+            file_count: result.file_count.unwrap_or(0),
+            max_line_length: count.max_line_length,
+            lines: count.lines,
+            words: count.words,
+            bytes: count.bytes,
+        })
     } else {
-        format!(
-            r#"{{"file":"{}","max_line_length":{},"lines":{},"words":{},"bytes":{}}}"#,
-            escape_json(&result.name),
-            result.count.max_line_length,
-            result.count.lines,
-            result.count.words,
-            result.count.bytes
-        )
+        JsonEntry::File(JsonFile {
+            file: &result.name,
+            max_line_length: count.max_line_length,
+            lines: count.lines,
+            words: count.words,
+            bytes: count.bytes,
+        })
     }
 }
 
-pub fn format_json_multiple(results: &[JsonFileResult], total: &Count) -> String {
-    let files_json: Vec<String> = results.iter().map(format_json_single).collect();
-    let total_file_count: usize = results.iter().map(|r| r.file_count.unwrap_or(1)).sum();
-
-    format!(
-        r#"{{"files":[{}],"total":{{"file_count":{},"max_line_length":{},"lines":{},"words":{},"bytes":{}}}}}"#,
-        files_json.join(","),
-        total_file_count,
-        total.max_line_length,
-        total.lines,
-        total.words,
-        total.bytes
-    )
+pub fn format_json_single(result: &JsonFileResult) -> String {
+    serde_json::to_string(&json_entry(result)).expect("JsonEntry serialization cannot fail")
 }
 
-fn escape_json(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t")
+pub fn format_json_multiple(results: &[JsonFileResult], total: &Count) -> String {
+    let files: Vec<JsonEntry> = results.iter().map(json_entry).collect();
+    let total_file_count: usize = results.iter().map(|r| r.file_count.unwrap_or(1)).sum();
+
+    let payload = JsonMultiple {
+        files,
+        total: JsonTotal {
+            file_count: total_file_count,
+            max_line_length: total.max_line_length,
+            lines: total.lines,
+            words: total.words,
+            bytes: total.bytes,
+        },
+    };
+
+    serde_json::to_string(&payload).expect("JsonMultiple serialization cannot fail")
 }
 
 pub fn format_total_output(file_count: usize, count: &Count, args: &Args) -> String {
@@ -529,5 +569,115 @@ mod tests {
         let output = format_compact_output("file.txt", &count, OutputKind::File, &args);
         assert!(output.contains("max:120"));
         assert!(!output.contains("lines"));
+    }
+
+    #[test]
+    fn json_single_escapes_all_control_characters_in_name() {
+        // Backspace, form feed, and escape are all legal in POSIX filenames
+        // but are not among \\, ", \n, \r, \t — the set a hand-rolled
+        // escaper would need to special-case individually.
+        let name = "a\u{08}b\u{0C}c\u{1B}d".to_string();
+        let result = JsonFileResult {
+            name,
+            count: Count::default(),
+            is_directory: false,
+            file_count: None,
+        };
+
+        let json = format_json_single(&result);
+
+        // Must be valid, parseable JSON with the exact original name recovered.
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["file"], "a\u{08}b\u{0C}c\u{1B}d");
+        // The raw bytes must not appear unescaped in the emitted JSON text.
+        assert!(!json.contains('\u{08}'));
+        assert!(!json.contains('\u{0C}'));
+        assert!(!json.contains('\u{1B}'));
+    }
+
+    #[test]
+    fn json_single_field_order_matches_documented_example() {
+        let result = JsonFileResult {
+            name: "file.txt".to_string(),
+            count: Count {
+                lines: 50,
+                words: 200,
+                bytes: 1500,
+                max_line_length: 120,
+            },
+            is_directory: false,
+            file_count: None,
+        };
+
+        let json = format_json_single(&result);
+        assert_eq!(
+            json,
+            r#"{"file":"file.txt","max_line_length":120,"lines":50,"words":200,"bytes":1500}"#
+        );
+    }
+
+    #[test]
+    fn json_single_directory_field_order_matches_documented_shape() {
+        let result = JsonFileResult {
+            name: "src".to_string(),
+            count: Count {
+                lines: 10,
+                words: 40,
+                bytes: 300,
+                max_line_length: 20,
+            },
+            is_directory: true,
+            file_count: Some(3),
+        };
+
+        let json = format_json_single(&result);
+        assert_eq!(
+            json,
+            r#"{"directory":"src","file_count":3,"max_line_length":20,"lines":10,"words":40,"bytes":300}"#
+        );
+    }
+
+    #[test]
+    fn json_multiple_escapes_control_characters_and_nests_total() {
+        let name = "weird\u{1B}name.txt".to_string();
+        let results = vec![
+            JsonFileResult {
+                name: name.clone(),
+                count: Count {
+                    lines: 1,
+                    words: 2,
+                    bytes: 10,
+                    max_line_length: 5,
+                },
+                is_directory: false,
+                file_count: None,
+            },
+            JsonFileResult {
+                name: "dir".to_string(),
+                count: Count {
+                    lines: 3,
+                    words: 4,
+                    bytes: 20,
+                    max_line_length: 8,
+                },
+                is_directory: true,
+                file_count: Some(2),
+            },
+        ];
+        let total = Count {
+            lines: 4,
+            words: 6,
+            bytes: 30,
+            max_line_length: 8,
+        };
+
+        let json = format_json_multiple(&results, &total);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["files"][0]["file"], "weird\u{1B}name.txt");
+        assert!(!json.contains('\u{1B}'));
+        assert_eq!(parsed["files"][1]["directory"], "dir");
+        assert_eq!(parsed["total"]["file_count"], 3); // 1 file + 2 in the directory
+        assert_eq!(parsed["total"]["lines"], 4);
     }
 }


### PR DESCRIPTION
## Summary
- `escape_json` only handled `\`, `"`, `\n`, `\r`, `\t`, but RFC 8259 requires *all* of U+0000–U+001F escaped inside JSON strings. A file or directory name containing another control byte (backspace, form feed, escape — all legal in POSIX filenames) was passed through raw, producing output strict JSON parsers reject.
- Replaced the hand-rolled `format!()`-based JSON assembly with `serde_json::to_string` over small `#[derive(Serialize)]` structs, per this repo's standing rule to use a serialization library rather than hand-roll JSON escaping. This eliminates the whole bug class rather than patching `escape_json` to cover the remaining control-char range (the issue's own suggested primary direction).
- Adds `serde` and `serde_json` as dependencies (not previously used in this crate) — the trade-off the issue explicitly flagged.
- Struct field order matches `spec.md`'s documented JSON output example (`file`/`directory`, `[file_count]`, `max_line_length`, `lines`, `words`, `bytes`) even though JSON field order isn't semantically significant, to avoid contradicting existing docs. `JsonEntry` uses `#[serde(untagged)]` so `JsonFile`/`JsonDirectory` still serialize as flat objects with no wrapper key, matching the previous shape exactly.

## Test plan
- [x] `cargo test` (78 unit + 40 integration)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] New tests: a name containing backspace/form-feed/escape round-trips correctly through `serde_json::from_str` and the raw control bytes don't appear unescaped in the emitted text; exact-string snapshots for both the file and directory JSON shapes confirm field order still matches `spec.md`; a multi-file test confirms `--json`'s nested `files`/`total` structure still escapes correctly

Closes #13