### PR TITLE
fix(main): report per-file errors and emit valid JSON on total failure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -104,9 +104,13 @@ fn run_json_mode(args: &Args) {
 
     for file in &args.files {
         let path = Path::new(file);
-        let Ok(result) = process_path(path, &config) else {
-            has_error = true;
-            continue;
+        let result = match process_path(path, &config) {
+            Ok(result) => result,
+            Err(e) => {
+                eprintln!("{WARNING_ICON}  {file}: {e}");
+                has_error = true;
+                continue;
+            }
         };
 
         if report_skipped(&result.skipped) {
@@ -124,7 +128,6 @@ fn run_json_mode(args: &Args) {
     }
 
     match results.as_slice() {
-        [] => {}
         [single] => println!("{}", format_json_single(single)),
         _ => println!("{}", format_json_multiple(&results, &total_count)),
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -518,6 +518,24 @@ fn json_mode_continues_after_error() {
     assert!(!result.success);
     assert!(result.stdout.contains("\"files\""));
     assert!(result.stdout.contains("\"total\""));
+    // The failing argument must be identifiable on stderr, matching normal
+    // mode's per-failure warning line.
+    assert!(result.stderr.contains("nonexistent.txt"));
+}
+
+#[test]
+fn json_mode_all_inputs_failing_prints_valid_json_and_reports_errors() {
+    let result = run_ewc(&["--json", "nonexistent1.txt", "nonexistent2.txt"]);
+
+    assert!(!result.success);
+    assert!(result.stderr.contains("nonexistent1.txt"));
+    assert!(result.stderr.contains("nonexistent2.txt"));
+
+    // stdout must still be a single well-formed JSON document, not empty.
+    let parsed: serde_json::Value =
+        serde_json::from_str(result.stdout.trim()).expect("stdout must be valid JSON");
+    assert_eq!(parsed["files"], serde_json::json!([]));
+    assert_eq!(parsed["total"]["file_count"], 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `run_json_mode` had two gaps compared to normal mode:
  1. A failed `process_path` was discarded silently (`let Ok(result) = ... else { continue }`, no stderr message) — exit code 1 gave no indication of which argument failed or why.
  2. If every argument failed, nothing was printed to stdout at all — not valid JSON for downstream consumers piping into a JSON parser.
- Fix: mirrored normal mode's per-failure warning line (same `⚠️  <file>: <error>` format) on the `process_path` `Err` path in JSON mode, and dropped the empty-results special case so the existing `format_json_multiple(&results, &total_count)` call — already correct for an empty slice (empty `files` array, zero `total`) — handles it uniformly with the multi-file path instead of printing nothing.

## Test plan
- [x] `cargo test` (78 unit + 41 integration)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] Strengthened the existing `json_mode_continues_after_error` test to assert the failing argument is identifiable on stderr; added `json_mode_all_inputs_failing_prints_valid_json_and_reports_errors`, which parses stdout with `serde_json::from_str` to confirm it's a well-formed document (`files: []`, `total.file_count: 0`) even when every input fails

Closes #12