### PR TITLE
fix(main): pick --json output shape by argument count, not success count

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,11 @@ fn run_stdin_mode(args: &Args) {
         Ok(c) => c,
         Err(e) => {
             eprintln!("{WARNING_ICON}  <stdin>: {e}");
+            if args.json {
+                // Keep stdout valid JSON even on failure, matching
+                // run_json_mode's all-inputs-failed behavior.
+                println!("{}", format_json_multiple(&[], &Count::default()));
+            }
             process::exit(1);
         }
     };
@@ -127,8 +132,14 @@ fn run_json_mode(args: &Args) {
         total_count += result.count;
     }
 
-    match results.as_slice() {
-        [single] => println!("{}", format_json_single(single)),
+    // Shape is chosen by how many arguments were given, not how many
+    // succeeded: otherwise `ewc --json good.txt bad.txt` (1 success of 2
+    // args) would return the bare single-object shape while
+    // `ewc --json bad1.txt bad2.txt` (0 successes) returns the {files,
+    // total} envelope — an unpredictable schema for a pipe consumer that
+    // can't know success counts ahead of time (#27).
+    match (args.files.len(), results.as_slice()) {
+        (1, [single]) => println!("{}", format_json_single(single)),
         _ => println!("{}", format_json_multiple(&results, &total_count)),
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -539,6 +539,49 @@ fn json_mode_all_inputs_failing_prints_valid_json_and_reports_errors() {
 }
 
 #[test]
+fn json_mode_two_args_one_success_uses_multi_file_envelope_shape() {
+    // A consumer passing N (>1) arguments must always get the {files,
+    // total} envelope shape, regardless of how many of them succeeded —
+    // not a bare single-object shape just because only one call happened
+    // to succeed (#27).
+    let file1 = create_test_file("hello\n");
+    let result = run_ewc(&["--json", file1.path().to_str().unwrap(), "nonexistent.txt"]);
+
+    assert!(!result.success);
+    let parsed: serde_json::Value =
+        serde_json::from_str(result.stdout.trim()).expect("stdout must be valid JSON");
+    assert!(
+        parsed.get("files").is_some(),
+        "expected envelope shape with a 'files' key, got: {parsed}"
+    );
+    assert_eq!(parsed["total"]["file_count"], 1);
+}
+
+#[test]
+#[cfg(unix)]
+fn stdin_json_mode_read_failure_prints_valid_json() {
+    // Reading from a directory fails at the OS level (EISDIR) even though
+    // opening it succeeds, giving a real stdin read error to test against
+    // — a read failure in --json mode must not leave stdout empty, matching
+    // the file-argument path's behavior on total failure (#27).
+    let dir = tempfile::tempdir().unwrap();
+    let dir_as_stdin = std::fs::File::open(dir.path()).expect("directories can be opened");
+
+    let output = Command::new("./target/debug/ewc")
+        .args(["--json"])
+        .stdin(std::process::Stdio::from(dir_as_stdin))
+        .output()
+        .expect("failed to run ewc");
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout must be valid JSON");
+    assert_eq!(parsed["files"], serde_json::json!([]));
+    assert_eq!(parsed["total"]["file_count"], 0);
+}
+
+#[test]
 fn directory_and_nonexistent_file() {
     let dir = create_test_dir();
     let result = run_ewc(&[dir.path().to_str().unwrap(), "nonexistent.txt"]);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -567,13 +567,15 @@ fn stdin_json_mode_read_failure_prints_valid_json() {
     let dir = tempfile::tempdir().unwrap();
     let dir_as_stdin = std::fs::File::open(dir.path()).expect("directories can be opened");
 
-    let output = Command::new("./target/debug/ewc")
+    let output = Command::new(env!("CARGO_BIN_EXE_ewc"))
         .args(["--json"])
         .stdin(std::process::Stdio::from(dir_as_stdin))
         .output()
         .expect("failed to run ewc");
 
     assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("<stdin>"));
     let stdout = String::from_utf8_lossy(&output.stdout);
     let parsed: serde_json::Value =
         serde_json::from_str(stdout.trim()).expect("stdout must be valid JSON");


### PR DESCRIPTION
## Summary
- `run_json_mode` chose between the bare single-object shape and the `{files, total}` envelope based on `results.len()` (how many arguments succeeded), not `args.files.len()` (how many were given). A pipe consumer passing N files couldn't predict the schema ahead of time: `ewc --json good.txt bad.txt` (1 success of 2 args) returned the bare object, while `ewc --json bad1.txt bad2.txt` (0 successes) returned the envelope — the same unpredictability #12 fixed for the all-fail case, just one step short.
- Fix: match on `(args.files.len(), results.as_slice())` so the envelope shape is used whenever more than one argument was given, regardless of success count; the bare shape is reserved for a single argument that succeeded.
- Related: `run_stdin_mode`'s `--json` path printed nothing to stdout on a `count_from_reader` failure — same class of bug, on the stdin path instead of the file-argument path. Now prints the same empty-envelope document `run_json_mode` uses for a fully-failed run, before exiting 1.

## Test plan
- [x] `cargo test` (81 unit + 44 integration)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] New tests: a "2 args, 1 success" case pins the envelope shape as the contract; a stdin-read-failure test using an opened directory as stdin (reading a directory reliably fails at the OS level even though opening it succeeds) genuinely exercises the new stdin error path rather than only the success path

Closes #27